### PR TITLE
Project updated to target .NET Standard 2.0 instead of .NET Core for better compatibility

### DIFF
--- a/SimpleProxy.Caching/SimpleProxy.Caching.csproj
+++ b/SimpleProxy.Caching/SimpleProxy.Caching.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SimpleProxy.Diagnostics/SimpleProxy.Diagnostics.csproj
+++ b/SimpleProxy.Diagnostics/SimpleProxy.Diagnostics.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SimpleProxy.Logging/SimpleProxy.Logging.csproj
+++ b/SimpleProxy.Logging/SimpleProxy.Logging.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SimpleProxy.UnitOfWork/SimpleProxy.UnitOfWork.csproj
+++ b/SimpleProxy.UnitOfWork/SimpleProxy.UnitOfWork.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SimpleProxy/InvocationContext.cs
+++ b/SimpleProxy/InvocationContext.cs
@@ -136,7 +136,7 @@
         /// <returns></returns>
         public object GetTemporaryData(string name)
         {
-            return this.TempData.GetValueOrDefault(name);
+            return this.TempData.TryGetValue(name, out var value) ? value : default;
         }
 
         /// <summary>

--- a/SimpleProxy/SimpleProxy.csproj
+++ b/SimpleProxy/SimpleProxy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Simple Proxy is a simple extension library built to solve the problem of Aspect Orientated Programming in Net Core projects</Description>
     <Copyright>Robert Perry</Copyright>
     <RepositoryUrl>https://github.com/f135ta/SimpleProxy</RepositoryUrl>

--- a/SimpleProxy/SimpleProxy.csproj
+++ b/SimpleProxy/SimpleProxy.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.3.1" />
+    <PackageReference Include="Castle.Core.AsyncInterceptor" Version="1.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />

--- a/SimpleProxy/SimpleProxy.csproj
+++ b/SimpleProxy/SimpleProxy.csproj
@@ -13,11 +13,4 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Runtime">
-      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.netcore.app\2.2.0\ref\netcoreapp2.2\System.Runtime.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Package for this solution in nuget only supports .NET Core 2.2 which I tried to use in one of my class libraries. But it didn't work because my library was targetted for .NET Standard 2.0. By adding support for .NET Standard 2.0, this library will be available for large number of other project types as well.

This pull request contains changes only for project files to target .NET Standard 2.0 and made change in InvocationContext.cs to support libraries in .NET Standard 2.0.

Edit: Removed additional reference for .NET Core found in SimpleProxy project file