### PR TITLE
Enable Async/Await Interception Update to .Net Core 3.1

### DIFF
--- a/SampleApp/ITestClass.cs
+++ b/SampleApp/ITestClass.cs
@@ -1,9 +1,15 @@
-﻿namespace SampleApp
+﻿using System.Threading.Tasks;
+
+
+namespace SampleApp
 {
     using System;
 
     public interface ITestClass
     {
         DateTime TestMethod();
+
+        Task<DateTime> TestMethodAsync();
+
     }
 }

--- a/SampleApp/Program.cs
+++ b/SampleApp/Program.cs
@@ -1,17 +1,21 @@
-﻿namespace SampleApp
-{
+﻿using System.Threading.Tasks;
+
+
+namespace SampleApp {
+    using System;
+
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
+
     using SimpleProxy.Caching;
     using SimpleProxy.Diagnostics;
     using SimpleProxy.Extensions;
     using SimpleProxy.Logging;
     using SimpleProxy.Strategies;
-    using System;
 
     public class Program
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
             // Configure the Service Provider
             var services = new ServiceCollection();
@@ -33,7 +37,12 @@
             var serviceProvider = services.BuildServiceProvider();
 
             var testProxy = serviceProvider.GetService<ITestClass>();
+
             testProxy.TestMethod();
+
+            await testProxy.TestMethodAsync();
+
+            Console.WriteLine("====> All Test Methods Complete.  Press a key. <====");
 
             Console.ReadLine();
         }

--- a/SampleApp/Program.cs
+++ b/SampleApp/Program.cs
@@ -1,8 +1,8 @@
-﻿using System.Threading.Tasks;
-
+﻿
 
 namespace SampleApp {
     using System;
+    using System.Threading.Tasks;
 
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.UnitOfWork" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.UnitOfWork" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SampleApp/TestClass.cs
+++ b/SampleApp/TestClass.cs
@@ -1,4 +1,7 @@
-﻿namespace SampleApp
+﻿using System.Threading.Tasks;
+
+
+namespace SampleApp
 {
     using System;
     using Microsoft.Extensions.Logging;
@@ -35,9 +38,23 @@
         {
             var dateTime = DateTime.Now;
 
-            this.logger.LogInformation($"====> The Real Method is Executed Here! <====");
+            this.logger.LogInformation("====> The Real Method is Executed Here! <====");
 
             return dateTime;
         }
+
+        [Log(LogLevel.Debug)]
+        [Diagnostics]
+        [Cache]
+        public Task<DateTime> TestMethodAsync()
+        {
+            var dateTime = DateTime.Now;
+
+            this.logger.LogInformation("====> The Real Async Method is Executed Here! <====");
+
+            return Task.FromResult(dateTime);
+        }
+
     }
+
 }

--- a/SimpleProxy.Caching/SimpleProxy.Caching.csproj
+++ b/SimpleProxy.Caching/SimpleProxy.Caching.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SimpleProxy.Diagnostics/SimpleProxy.Diagnostics.csproj
+++ b/SimpleProxy.Diagnostics/SimpleProxy.Diagnostics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SimpleProxy.Logging/SimpleProxy.Logging.csproj
+++ b/SimpleProxy.Logging/SimpleProxy.Logging.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SimpleProxy.UnitOfWork/IUnitOfWorkFactory.cs
+++ b/SimpleProxy.UnitOfWork/IUnitOfWorkFactory.cs
@@ -1,4 +1,7 @@
-﻿namespace SimpleProxy.UnitOfWork
+﻿using Arch.EntityFrameworkCore.UnitOfWork;
+
+
+namespace SimpleProxy.UnitOfWork
 {
     using Microsoft.EntityFrameworkCore;
 

--- a/SimpleProxy.UnitOfWork/SimpleProxy.UnitOfWork.csproj
+++ b/SimpleProxy.UnitOfWork/SimpleProxy.UnitOfWork.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.UnitOfWork" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.UnitOfWork" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SimpleProxy.UnitOfWork/UnitOfWorkFactory.cs
+++ b/SimpleProxy.UnitOfWork/UnitOfWorkFactory.cs
@@ -1,4 +1,7 @@
-﻿namespace SimpleProxy.UnitOfWork
+﻿using Arch.EntityFrameworkCore.UnitOfWork;
+
+
+namespace SimpleProxy.UnitOfWork
 {
     using System;
     using Microsoft.EntityFrameworkCore;

--- a/SimpleProxy.UnitOfWork/UnitOfWorkInterceptor.cs
+++ b/SimpleProxy.UnitOfWork/UnitOfWorkInterceptor.cs
@@ -1,4 +1,7 @@
-﻿namespace SimpleProxy.UnitOfWork
+﻿using Arch.EntityFrameworkCore.UnitOfWork;
+
+
+namespace SimpleProxy.UnitOfWork
 {
     using System.Linq;
     using Extensions;

--- a/SimpleProxy/Extensions/ServiceCollectionExtensions.cs
+++ b/SimpleProxy/Extensions/ServiceCollectionExtensions.cs
@@ -94,7 +94,7 @@
 
             // Wrap the service with a Proxy instance and add it with Singleton Scope
             services.AddSingleton(typeof(TInterface), p => new ProxyFactory<TInterface>(serviceProvider, proxyGenerator, proxyConfiguration).CreateProxy(proxyInstance));
-            
+
             // Return the IServiceCollection for chaining configuration
             return services;
         }

--- a/SimpleProxy/Internal/CoreInterceptor.cs
+++ b/SimpleProxy/Internal/CoreInterceptor.cs
@@ -1,4 +1,9 @@
-﻿namespace SimpleProxy.Internal
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using SimpleProxy.Interfaces;
+
+
+namespace SimpleProxy.Internal
 {
     using System;
     using System.Linq;
@@ -9,7 +14,7 @@
     /// <summary>
     /// The Master Interceptor Class wraps a proxied object and handles all of its interceptions
     /// </summary>
-    internal class CoreInterceptor : IInterceptor
+    internal class CoreInterceptor : IAsyncInterceptor
     {
         /// <summary>
         /// Gets the <see cref="proxyConfiguration"/>
@@ -32,39 +37,112 @@
             this.proxyConfiguration = proxyConfiguration;
         }
 
-        /// <inheritdoc />
-        public void Intercept(IInvocation invocation)
+        public void InterceptSynchronous(IInvocation invocation)
         {
-            // Map the configured interceptors to this type based on its attributes
-            var invocationMetadataCollection = InvocationExtensions.GetInterceptorMetadataForMethod(invocation, this.serviceProvider, this.proxyConfiguration);
+            var proceedWithInterception = InterceptBeforeProceed(invocation, out var invocationMetadataCollection, out var orderingStrategy);
 
-            // If there are no configured interceptors, leave now
-            if (invocationMetadataCollection == null || !invocationMetadataCollection.Any())
-            {
+            if (!proceedWithInterception) {
                 invocation.Proceed();
                 return;
             }
 
-            // Get the Ordering Strategy for Interceptors
-            var orderingStrategy = this.proxyConfiguration.OrderingStrategy;
-
-            // Process the BEFORE Interceptions
-            foreach (var invocationContext in orderingStrategy.OrderBeforeInterception(invocationMetadataCollection))
-            {
-                invocationContext.Interceptor.BeforeInvoke(invocationContext);
-            }
-
             // Execute the Real Method
-            if (!invocationMetadataCollection.Any(p => p.InvocationIsBypassed))
-            {
+            if (!invocationMetadataCollection.Any(p => p.InvocationIsBypassed)) {
                 invocation.Proceed();
             }
 
+            InterceptAfterProceed(invocationMetadataCollection, orderingStrategy);
+        }
+
+        public void InterceptAsynchronous(IInvocation invocation)
+        {
+            invocation.ReturnValue = InternalInterceptAsynchronousAsync(invocation);
+        }
+
+        private async Task InternalInterceptAsynchronousAsync(IInvocation invocation)
+        {
+            var proceedWithInterception = InterceptBeforeProceed(invocation, out var invocationMetadataCollection, out var orderingStrategy);
+
+            if (!proceedWithInterception) {
+                invocation.Proceed();
+                var task = (Task)invocation.ReturnValue;
+                await task;
+                return;
+            }
+
+            // Execute the Real Method
+            if (!invocationMetadataCollection.Any(p => p.InvocationIsBypassed)) {
+                invocation.Proceed();
+                var task = (Task)invocation.ReturnValue;
+                await task;
+            }
+
+            InterceptAfterProceed(invocationMetadataCollection, orderingStrategy);
+        }
+
+        public void InterceptAsynchronous<TResult>(IInvocation invocation)
+        {
+            invocation.ReturnValue = InternalInterceptAsynchronousAsync<TResult>(invocation);
+        }
+
+        private async Task<TResult> InternalInterceptAsynchronousAsync<TResult>(IInvocation invocation)
+        {
+            var proceedWithInterception = InterceptBeforeProceed(invocation, out var invocationMetadataCollection, out var orderingStrategy);
+
+            TResult result;
+
+            if (!proceedWithInterception) {
+                invocation.Proceed();
+                var task = (Task<TResult>)invocation.ReturnValue;
+                result = await task;
+                return result;
+            }
+
+            // Execute the Real Method
+            if (!invocationMetadataCollection.Any(p => p.InvocationIsBypassed)) {
+                invocation.Proceed();
+                var task = (Task<TResult>)invocation.ReturnValue;
+                result = await task;
+            }
+            else {
+                result = default;
+            }
+
+            InterceptAfterProceed(invocationMetadataCollection, orderingStrategy);
+
+            return result;
+        }
+
+        private bool InterceptBeforeProceed(IInvocation invocation, out List<InvocationContext> invocationMetadataCollection, out IOrderingStrategy orderingStrategy)
+        {
+            // Map the configured interceptors to this type based on its attributes
+            invocationMetadataCollection = InvocationExtensions.GetInterceptorMetadataForMethod(invocation, this.serviceProvider, this.proxyConfiguration);
+
+            // If there are no configured interceptors, leave now
+            if (invocationMetadataCollection == null || !invocationMetadataCollection.Any()) {
+                orderingStrategy = null;
+                return false;
+            }
+
+            // Get the Ordering Strategy for Interceptors
+            orderingStrategy = this.proxyConfiguration.OrderingStrategy;
+
+            // Process the BEFORE Interceptions
+            foreach (var invocationContext in orderingStrategy.OrderBeforeInterception(invocationMetadataCollection)) {
+                invocationContext.Interceptor.BeforeInvoke(invocationContext);
+            }
+
+            return true;
+        }
+
+        private static void InterceptAfterProceed(List<InvocationContext> invocationMetadataCollection, IOrderingStrategy orderingStrategy)
+        {
             // Process the AFTER Interceptions
-            foreach (var invocationContext in orderingStrategy.OrderAfterInterception(invocationMetadataCollection))
-            {
+            foreach (var invocationContext in orderingStrategy.OrderAfterInterception(invocationMetadataCollection)) {
                 invocationContext.Interceptor.AfterInvoke(invocationContext, invocationContext.GetMethodReturnValue());
             }
         }
+
     }
+
 }

--- a/SimpleProxy/Internal/CoreInterceptor.cs
+++ b/SimpleProxy/Internal/CoreInterceptor.cs
@@ -1,15 +1,15 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using SimpleProxy.Interfaces;
-
+﻿
 
 namespace SimpleProxy.Internal
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using Castle.DynamicProxy;
     using Extensions;
     using SimpleProxy.Configuration;
+    using SimpleProxy.Interfaces;
 
     /// <summary>
     /// The Master Interceptor Class wraps a proxied object and handles all of its interceptions

--- a/SimpleProxy/SimpleProxy.csproj
+++ b/SimpleProxy/SimpleProxy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Description>Simple Proxy is a simple extension library built to solve the problem of Aspect Orientated Programming in Net Core projects</Description>
     <Copyright>Robert Perry</Copyright>
     <RepositoryUrl>https://github.com/f135ta/SimpleProxy</RepositoryUrl>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="Castle.Core.AsyncInterceptor" Version="1.7.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SimpleProxy/SimpleProxy.csproj
+++ b/SimpleProxy/SimpleProxy.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.3.1" />
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
+    <PackageReference Include="Castle.Core.AsyncInterceptor" Version="1.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />

--- a/SimpleProxy/SimpleProxy.csproj
+++ b/SimpleProxy/SimpleProxy.csproj
@@ -15,10 +15,4 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Runtime">
-      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.netcore.app\2.2.0\ref\netcoreapp2.2\System.Runtime.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>

--- a/Unit Tests/SimpleProxy.Tests/SimpleProxy.Tests.csproj
+++ b/Unit Tests/SimpleProxy.Tests/SimpleProxy.Tests.csproj
@@ -1,15 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added Castle.Core.AsyncInverceptor Nuget package.
Updated Castle.Core to latest version.
Changed CoreInterceptor class to use the IAsyncInterceptor interface.
Added all additional methods needed for the interface.
Changed the SampleApp to add a test using async/await.